### PR TITLE
Remove `using Pkg` in `build.jl`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,3 @@
-using Pkg
-
 scenred2depsdir = dirname(@__FILE__)
 
 depsfile = joinpath(scenred2depsdir,"deps.jl")


### PR DESCRIPTION
Haven't tested, but it doesn't look like you're using `Pkg`?

Reported by: https://discourse.julialang.org/t/how-to-solve-this-error-while-installing-scenred2/35413